### PR TITLE
Timeout for Nsq::connectNsqd()

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ $nsq->subscribe($nsq_lookupd, $config, function($msg,$bev){
 
 * `subscribe($nsq_lookupd,$config,$callback)` <br/>
 
+* `conn_timeout = 100`<br />
+  connection timeout for `connectNsqd()` in milliseconds
+
 ### Message Object
 
 The following properties and methods are available on Message objects produced by a Reader

--- a/nsq.c
+++ b/nsq.c
@@ -577,6 +577,7 @@ PHP_MINIT_FUNCTION (nsq)
     nsq_ce = zend_register_internal_class(&nsq TSRMLS_CC);
     zend_declare_property_null(nsq_ce,ZEND_STRL("nsqConfig"),ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(nsq_ce, ZEND_STRL("nsqd_connection_fds"), ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(nsq_ce, ZEND_STRL("conn_timeout"), ZEND_ACC_PUBLIC TSRMLS_CC);
     le_bufferevent = zend_register_list_destructors_ex(_php_bufferevent_dtor, NULL, "buffer event", module_number);
 
     lookupd_init();


### PR DESCRIPTION
When NSQD is not available the Nsq::connectNsqd() hangs until php max execution time is reached. It should be possible to configure a timeout.

This pull request introduces a new member variable to the `Nsq` class called `conn_timeout`. Before connecting to NSQD the user can configure a timeout in milliseconds.

Example:
``` 
$nsq = new Nsq();
$nsq->conn_timeout = 30;
$nsq->connectNsqd(array("127.0.0.1:4150"))
```
The timeout is achived by setting `SO_SNDTIMEO` via `setsockopt` while connecting. After a successfull connection the timeout is reset to the OS default.

I hope my contribution is worth considering to merge.

Kind regards,
Maxi
