### PR TITLE
docs: fix simple typo, intall -> install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NSQ  client for php7 .  QQ Group : 616063018<br/>
 - fixed https://github.com/yunnian/php-nsq/issues/39
 message are binary-safe now
 
-### intall :
+### install :
 
     Dependencies: libevent  (apt-get install libevent-dev ,yum install libevent-devel)
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `install` rather than `intall`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md